### PR TITLE
support ruby-2.4.0

### DIFF
--- a/jr-cli.gemspec
+++ b/jr-cli.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "yajl-ruby", "~> 1.2.1"
+  spec.add_runtime_dependency "yajl-ruby", "~> 1.2"
   spec.add_runtime_dependency "coderay", "~> 1.1.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
yajl 1.2.x has a building problem with ruby-2.4.0.

see https://github.com/brianmario/yajl-ruby/pull/165 and https://github.com/tmm1/pygments.rb/pull/164