### PR TITLE
Fix --raw-output to show Symbol as a raw String

### DIFF
--- a/bin/jr
+++ b/bin/jr
@@ -71,7 +71,7 @@ result = input_enumerator.instance_eval(jr_filter)
 
 encoder = Yajl::Encoder.new(pretty: pretty)
 print_json = ->(data) do
-  if raw_output and data.is_a? String
+  if raw_output && (data.is_a?(String) || data.is_a?(Symbol))
     puts data
   else
     if color_output

--- a/features/json_processing.feature
+++ b/features/json_processing.feature
@@ -268,6 +268,25 @@ Feature: JSON processing
 
     """
 
+  Scenario: Output symbols as raw output using --raw-output option
+    Given a file named "input.json" with:
+    """
+    {
+      "foo": true,
+      "bar": true,
+      "baz": true
+    }
+
+    """
+    When I run `jr --raw-output 'map(&:keys).unwrap' input.json`
+    Then the output should contain exactly:
+    """
+    foo
+    bar
+    baz
+
+    """
+
   Scenario: Read each line as string using --raw-input option
     Given a file named "input.json" with:
     """


### PR DESCRIPTION
This may happen when showing keys of Hash because they're symbolized

## Before

```
$ echo '{"foo":true}' | jr 'map(&:keys).unwrap' -r
"foo"
```

## After

```
$ echo '{"foo":true}' | jr 'map(&:keys).unwrap' -r
foo
```