### PR TITLE
Fix warning from aruba

### DIFF
--- a/features/step_definitions/command_steps.rb
+++ b/features/step_definitions/command_steps.rb
@@ -1,4 +1,4 @@
 When(/^I run `([^`]*)` in bash$/)do |cmd|
   cmd = "bash -c '%s'" % unescape_text(unescape_text(cmd))
-  run_simple(cmd, false)
+  run_command_and_stop(cmd, exit_timeout: 5)
 end


### PR DESCRIPTION
https://github.com/yuya-takeyama/jr/runs/7205101043?check_suite_focus=true#step:4:96
```
The use of "#run_simple" is deprecated. Use "run_command_and_stop" instead. Called by /home/runner/work/jr/jr/features/step_definitions/command_steps.rb:3:in `block in <top (required)>'
Please pass options to `#run_command_and_stop` as named parameters/hash and don't use the old style with positional parameters, NEW: e.g. `#run_command_and_stop('cmd', :exit_timeout => 5)`.. Called by /home/runner/work/jr/jr/vendor/bundle/ruby/3.0.0/gems/aruba-0.14.14/lib/aruba/api/deprecated.rb:206:in `run_simple'
```