### PR TITLE
Fix warning

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ Rake::TestTask.new(:test) do |t|
 end
 
 Cucumber::Rake::Task.new(:features) do |t|
-  t.cucumber_opts = "features --format pretty"
+  t.cucumber_opts = %w(features --format pretty)
 end
 
 task :default => [:test, :features]


### PR DESCRIPTION
https://github.com/yuya-takeyama/jr/runs/7206025358?check_suite_focus=true#step:5:5
```
WARNING: consider using an array rather than a space-delimited string with cucumber_opts to avoid undesired behavior.
```